### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -598,7 +598,7 @@ footer .social-media a i {
     }
 
    .service-card .close-btn {
-        position: absolute;
+        position: relative;
         top: 5px;
         right: 5px;
         font-size: 1.5em;


### PR DESCRIPTION
Fix modal close button to appear in the middle of the modal on devices with a screen width bigger than 480px and less than whatever the next size up was - I can't remember!